### PR TITLE
Fix UDIF.ReadStream() not reading entire image

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,23 +96,19 @@ KolyBlock {
   flags: 1,
   runningDataForkOffset: 0,
   dataForkOffset: 0,
-  dataForkLength: 58423161,
+  dataForkLength: 6585140266,
   resourceForkOffset: 0,
   resourceForkLength: 0,
   segmentNumber: 1,
   segmentCount: 1,
-  segmentId: <Buffer 57 7e fa dc 18 96 46 36 89 93 6d e6 59 6e 36 1c>,
-  dataChecksumType: 2,
-  dataChecksumSize: 32,
-  dataChecksum: '57751645',
-  xmlOffset: 58423161,
-  xmlLength: 18424,
-  reserved1: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... >,
-  checksumType: 2,
-  checksumSize: 32,
-  checksum: '29dc317d',
+  segmentId: <Buffer 18 66 9e 31 fa 6 d 4 f 7 d aa d0 f2 50 12 8 f 49 54>,
+  dataChecksum: Checksum { type: 2, bits: 32, value: 'c2208200' },
+  xmlOffset: 6585140266,
+  xmlLength: 1752206,
+  reserved1: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ...>,
+  checksum: Checksum { type: 2, bits: 32, value: '3f40bb47' },
   imageVariant: 1,
-  sectorCount: 1228800,
+  sectorCount: 15178432,
   reserved2: 0,
   reserved3: 0,
   reserved4: 0,
@@ -125,131 +121,313 @@ The XML data is a [Property List](https://en.wikipedia.org/wiki/Property_list), 
 
 ```js
 dmg.open( function( error ) {
-  console.log( dmg.resources )
+  console.log( dmg.resourceFork )
 })
 ```
 
 ```js
-[{
-  id: -1,
-  attributes: 80,
-  name: 'Protective Master Boot Record (MBR : 0)',
-  coreFoundationName: 'Protective Master Boot Record (MBR : 0)',
-  map: BlockMap {
-    signature: 1835627368,
-    version: 1,
-    sectorNumber: 0,
-    sectorCount: 1,
-    dataOffset: 0,
-    buffersNeeded: 2056,
-    blockDescriptorCount: 0,
-    // reserved fields omitted for brevity
-    checksumType: 2,
-    checksumSize: 32,
-    checksum: 'baa01cf3',
-    blockCount: 2,
-    blocks: [
-      Block {
-        type: 2147483653,
-        description: 'UDZO (UDIF zlib-compressed)',
-        comment: '',
-        sectorNumber: 0,
-        sectorCount: 1,
-        compressedOffset: 0,
-        compressedLength: 30
-      },
-      Block {
-        type: 4294967295,
-        description: 'TERMINATOR',
-        comment: '',
-        sectorNumber: 1,
-        sectorCount: 0,
-        compressedOffset: 30,
-        compressedLength: 0
-      }
-    ]
-  }
-}, {
-  id: 0,
-  attributes: 80,
-  name: 'GPT Header (Primary GPT Header : 1)',
-  coreFoundationName: 'GPT Header (Primary GPT Header : 1)',
-  map: BlockMap {
-    signature: 1835627368,
-    version: 1,
-    sectorNumber: 1,
-    sectorCount: 1,
-    dataOffset: 0,
-    buffersNeeded: 2056,
-    blockDescriptorCount: 1,
-    // reserved fields omitted for brevity
-    checksumType: 2,
-    checksumSize: 32,
-    checksum: '954e054b',
-    blockCount: 2,
-    blocks: [
-      Block {
-        type: 2147483653,
-        description: 'UDZO (UDIF zlib-compressed)',
-        comment: '',
-        sectorNumber: 0,
-        sectorCount: 1,
-        compressedOffset: 30,
-        compressedLength: 75
-      },
-      Block {
-        type: 4294967295,
-        description: 'TERMINATOR',
-        comment: '',
-        sectorNumber: 1,
-        sectorCount: 0,
-        compressedOffset: 105,
-        compressedLength: 0
-      }
-    ]
-  }
-},
-// ... more omitted for brevity ...
 {
-  id: 6,
-  attributes: 80,
-  name: 'GPT Header (Backup GPT Header : 7)',
-  coreFoundationName: 'GPT Header (Backup GPT Header : 7)',
-  map: BlockMap {
-    signature: 1835627368,
-    version: 1,
-    sectorNumber: 1228799,
-    sectorCount: 1,
-    dataOffset: 0,
-    buffersNeeded: 2056,
-    blockDescriptorCount: 7,
-    // reserved fields omitted for brevity
-    checksumType: 2,
-    checksumSize: 32,
-    checksum: 'beda967a',
-    blockCount: 2,
-    blocks: [
-      Block {
-        type: 2147483653,
-        description: 'UDZO (UDIF zlib-compressed)',
-        comment: '',
-        sectorNumber: 0,
-        sectorCount: 1,
-        compressedOffset: 58423085,
-        compressedLength: 76
-      },
-      Block {
-        type: 4294967295,
-        description: 'TERMINATOR',
-        comment: '',
-        sectorNumber: 1,
-        sectorCount: 0,
-        compressedOffset: 58423161,
-        compressedLength: 0
-      }
-    ]
-  }
-}]
+  blkx: [{
+    id: -1,
+    attributes: 80,
+    name: 'Driver Descriptor Map (DDM : 0)',
+    coreFoundationName: 'Driver Descriptor Map (DDM : 0)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 0,
+      sectorCount: 1,
+      dataOffset: 0,
+      buffersNeeded: 520,
+      blockDescriptorCount: 0,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: '698a85ed' },
+      blockCount: 2,
+      blocks: [
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 1,
+          compressedOffset: 0,
+          compressedLength: 22
+        },
+        Block {
+          type: 4294967295,
+          description: 'TERMINATOR',
+          comment: '',
+          sectorNumber: 1,
+          sectorCount: 0,
+          compressedOffset: 22,
+          compressedLength: 0
+        }
+      ]
+    }
+  }, {
+    id: 0,
+    attributes: 80,
+    name: 'WINDOWSSUPPORT (Apple_ISO : 1)',
+    coreFoundationName: 'WINDOWSSUPPORT (Apple_ISO : 1)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 1,
+      sectorCount: 3,
+      dataOffset: 0,
+      buffersNeeded: 520,
+      blockDescriptorCount: 1,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: '6c1ce17e' },
+      blockCount: 2,
+      blocks: [
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 3,
+          compressedOffset: 22,
+          compressedLength: 24
+        },
+        Block {
+          type: 4294967295,
+          description: 'TERMINATOR',
+          comment: '',
+          sectorNumber: 3,
+          sectorCount: 0,
+          compressedOffset: 46,
+          compressedLength: 0
+        }
+      ]
+    }
+  }, {
+    id: 1,
+    attributes: 80,
+    name: 'Apple (Apple_partition_map : 2)',
+    coreFoundationName: 'Apple (Apple_partition_map : 2)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 4,
+      sectorCount: 60,
+      dataOffset: 0,
+      buffersNeeded: 520,
+      blockDescriptorCount: 2,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: '115fc68e' },
+      blockCount: 2,
+      blocks: [
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 60,
+          compressedOffset: 46,
+          compressedLength: 358
+        },
+        Block {
+          type: 4294967295,
+          description: 'TERMINATOR',
+          comment: '',
+          sectorNumber: 60,
+          sectorCount: 0,
+          compressedOffset: 404,
+          compressedLength: 0
+        }
+      ]
+    }
+  }, {
+    id: 2,
+    attributes: 80,
+    name: 'Macintosh (Apple_Driver_ATAPI : 3)',
+    coreFoundationName: 'Macintosh (Apple_Driver_ATAPI : 3)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 64,
+      sectorCount: 2020420,
+      dataOffset: 0,
+      buffersNeeded: 520,
+      blockDescriptorCount: 3,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: 'b2bb86f8' },
+      blockCount: 3948,
+      blocks: [
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 512,
+          compressedOffset: 404,
+          compressedLength: 25147
+        },
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 512,
+          sectorCount: 512,
+          compressedOffset: 25551,
+          compressedLength: 29149
+        },
+        ... more items
+      ]
+    }
+  }, {
+    id: 3,
+    attributes: 80,
+    name: ' (Apple_Free : 4)',
+    coreFoundationName: ' (Apple_Free : 4)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 2020484,
+      sectorCount: 4,
+      dataOffset: 0,
+      buffersNeeded: 0,
+      blockDescriptorCount: 4,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: '00000000' },
+      blockCount: 2,
+      blocks: [
+        Block {
+          type: 2,
+          description: 'FREE (unallocated)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 4,
+          compressedOffset: 984141554,
+          compressedLength: 0
+        },
+        Block {
+          type: 4294967295,
+          description: 'TERMINATOR',
+          comment: '',
+          sectorNumber: 4,
+          sectorCount: 0,
+          compressedOffset: 984141554,
+          compressedLength: 0
+        }
+      ]
+    }
+  }, {
+    id: 4,
+    attributes: 80,
+    name: 'Mac_OS_X (Apple_HFS : 5)',
+    coreFoundationName: 'Mac_OS_X (Apple_HFS : 5)',
+    map: BlockMap {
+      signature: 1835627368,
+      version: 1,
+      sectorNumber: 2020488,
+      sectorCount: 13157944,
+      dataOffset: 0,
+      buffersNeeded: 520,
+      blockDescriptorCount: 5,
+      reserved1: 0,
+      reserved2: 0,
+      reserved3: 0,
+      reserved4: 0,
+      reserved5: 0,
+      reserved6: 0,
+      checksum: Checksum { type: 2, bits: 32, value: '39ce04b6' },
+      blockCount: 25387,
+      blocks: [
+        Block {
+          type: 2147483646,
+          description: 'COMMENT',
+          comment: '+beg',
+          sectorNumber: 0,
+          sectorCount: 0,
+          compressedOffset: 984141554,
+          compressedLength: 0
+        },
+        Block {
+          type: 2147483653,
+          description: 'UDZO (zlib-compressed)',
+          comment: '',
+          sectorNumber: 0,
+          sectorCount: 512,
+          compressedOffset: 984141554,
+          compressedLength: 1812
+        },
+        ... more items
+      ]
+    }
+  }],
+  cSum: [{
+    Attributes: '0x0000',
+    Data: <Buffer 01 00 02 00 00 00 00 00 00 00>,
+    ID: '0',
+    Name: null
+  }, {
+    Attributes: '0x0000',
+    Data: <Buffer 01 00 02 00 00 00 10 fc a8 3f>,
+    ID: '1',
+    Name: null
+  }, {
+    Attributes: '0x0000',
+    Data: <Buffer 01 00 02 00 00 00 10 37 71 ef>,
+    ID: '2',
+    Name: null
+  }],
+  nsiz: [{
+    Attributes: '0x0000',
+    Data: <Buffer 3 c 3 f 78 6 d 6 c 20 76 65 72 73 69 6 f 6e 3 d 22 31 2e 30 22 20 65 6e 63 6 f 64 69 6e 67 3 d 22 55 54 46 2 d 38 22 3 f 3e 0 a 3 c 21 44 4 f 43 54 59 50 45 20 70 ...>,
+    ID: '0',
+    Name: null
+  }, {
+    Attributes: '0x0000',
+    Data: <Buffer 3 c 3 f 78 6 d 6 c 20 76 65 72 73 69 6 f 6e 3 d 22 31 2e 30 22 20 65 6e 63 6 f 64 69 6e 67 3 d 22 55 54 46 2 d 38 22 3 f 3e 0 a 3 c 21 44 4 f 43 54 59 50 45 20 70 ...>,
+    ID: '1',
+    Name: null
+  }, {
+    Attributes: '0x0000',
+    Data: <Buffer 3 c 3 f 78 6 d 6 c 20 76 65 72 73 69 6 f 6e 3 d 22 31 2e 30 22 20 65 6e 63 6 f 64 69 6e 67 3 d 22 55 54 46 2 d 38 22 3 f 3e 0 a 3 c 21 44 4 f 43 54 59 50 45 20 70 ...>,
+    ID: '2',
+    Name: null
+  }],
+  plst: [{
+    Attributes: '0x0050',
+    Data: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ...>,
+    ID: '0',
+    Name: null
+  }],
+  size: [{
+    Attributes: '0x0000',
+    Data: <Buffer 05 00 01 00 00 00 00 60 8 c 91 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ...>,
+    ID: '2',
+    Name: null
+  }]
+}
+
 ```
 
 ## References

--- a/lib/block.js
+++ b/lib/block.js
@@ -36,11 +36,11 @@ function Block() {
 Block.getDescription = function( type ) {
   switch( type ) {
     case UDIF.BLOCK.ZEROFILL: return 'ZEROFILL'; break
-    case UDIF.BLOCK.RAW: return 'UDRW (UDIF read/write) / UDRO (UDIF read-only)'; break
-    case UDIF.BLOCK.FREE: return 'FREE (Unallocated)'; break
-    case UDIF.BLOCK.UDCO: return 'UDCO (UDIF ADC-compressed)'; break
-    case UDIF.BLOCK.UDZO: return 'UDZO (UDIF zlib-compressed)'; break
-    case UDIF.BLOCK.UDBZ: return 'UDBZ (UDIF bzip2-compressed)'; break
+    case UDIF.BLOCK.RAW: return 'UDRW (raw)'; break
+    case UDIF.BLOCK.FREE: return 'FREE (unallocated)'; break
+    case UDIF.BLOCK.UDCO: return 'UDCO (adc-compressed)'; break
+    case UDIF.BLOCK.UDZO: return 'UDZO (zlib-compressed)'; break
+    case UDIF.BLOCK.UDBZ: return 'UDBZ (bzip2-compressed)'; break
     case UDIF.BLOCK.COMMENT: return 'COMMENT'; break
     case UDIF.BLOCK.TERMINATOR: return 'TERMINATOR'; break
     default: return 'UNKNOWN'; break

--- a/lib/blockmap.js
+++ b/lib/blockmap.js
@@ -1,3 +1,5 @@
+var UDIF = require( './udif' )
+
 /**
  * BlockMap (BLKX) data (aka Mish Data)
  * @constructor
@@ -22,9 +24,7 @@ function BlockMap() {
   this.reserved4 = 0x00000000
   this.reserved5 = 0x00000000
   this.reserved6 = 0x00000000
-  this.checksumType = 0x00000000
-  this.checksumSize = 0x00000000 // size in bits (0-1024 bits supported)
-  this.checksum = '' // Buffer.alloc( 128, 0 )
+  this.checksum = new UDIF.Checksum()
   this.blockCount = 0x00000000
   this.blocks = []
 
@@ -93,9 +93,7 @@ BlockMap.prototype = {
     this.reserved4 = buffer.readUInt32BE( offset + 52 )
     this.reserved5 = buffer.readUInt32BE( offset + 56 )
     this.reserved6 = buffer.readUInt32BE( offset + 60 )
-    this.checksumType = buffer.readUInt32BE( offset + 64 )
-    this.checksumSize = buffer.readUInt32BE( offset + 68 )
-    this.checksum = buffer.toString( 'hex', offset + 72, offset + 72 + this.checksumSize / 8 )
+    this.checksum.parse( buffer, offset + 64 )
     this.blockCount = buffer.readUInt32BE( offset + 200 )
     this.blocks = []
 

--- a/lib/checksum.js
+++ b/lib/checksum.js
@@ -1,0 +1,70 @@
+var UDIF = require( './udif' )
+
+/**
+ * UDIF Checksum Structure
+ * @constructor
+ * @memberOf UDIF
+ * @returns {Checksum}
+ */
+function Checksum() {
+
+  if( !(this instanceof Checksum) ) {
+    return new Checksum()
+  }
+
+  /** @type {Number} Checksum type (uint32) */
+  this.type = UDIF.CHECKSUM_TYPE.NONE
+  /** @type {Number} Checksum size in bits (uint32) */
+  this.bits = 0x00000000
+  /** @type {String} Checksum as hex string */
+  this.value = ''
+
+}
+
+/**
+ * Checksum struct size in bytes
+ * @todo verify correctness of this value
+ * @type {Number}
+ */
+Checksum.size = 128
+
+/**
+ * Parse a UDIF checksum struct from a buffer
+ * @param {Buffer} buffer
+ * @param {Number} [offset]
+ * @returns {Checksum}
+ */
+Checksum.parse = function( buffer, offset ) {
+  return new Checksum().parse( buffer, offset )
+}
+
+/**
+ * Checksum prototype
+ * @ignore
+ */
+Checksum.prototype = {
+
+  constructor: Checksum,
+
+  /**
+   * Parse a UDIF checksum struct from a buffer
+   * @param {Buffer} buffer
+   * @param {Number} [offset]
+   * @returns {Checksum}
+   */
+  parse( buffer, offset ) {
+
+    offset = offset || 0
+
+    this.type = buffer.readUInt32BE( offset + 0 )
+    this.bits = buffer.readUInt32BE( offset + 4 )
+    this.value = buffer.toString( 'hex', offset + 8, offset + 8 + this.bits / 8 )
+
+    return this
+
+  },
+
+}
+
+// Exports
+module.exports = Checksum

--- a/lib/footer.js
+++ b/lib/footer.js
@@ -23,15 +23,11 @@ function KolyBlock() {
   this.segmentNumber = 0
   this.segmentCount = 0
   this.segmentId = new Buffer( 16 )
-  this.dataChecksumType = 0
-  this.dataChecksumSize = 0
-  this.dataChecksum = ''
+  this.dataChecksum = new UDIF.Checksum()
   this.xmlOffset = 0
   this.xmlLength = 0
   this.reserved1 = new Buffer( 120 )
-  this.checksumType = 0
-  this.checksumSize = 0
-  this.checksum = ''
+  this.checksum = new UDIF.Checksum()
   this.imageVariant = 0
   this.sectorCount = 0
   this.reserved2 = 0
@@ -111,19 +107,14 @@ KolyBlock.prototype = {
 
     buffer.copy( this.segmentId, 0, offset + 64, offset + 64 + 16 )
 
-    this.dataChecksumType = buffer.readUInt32BE( offset + 80 )
-    this.dataChecksumSize = buffer.readUInt32BE( offset + 84 )
-    this.dataChecksum = buffer.toString( 'hex', offset + 88, offset + 88 + this.dataChecksumSize / 8 )
+    this.dataChecksum.parse( buffer, offset + 80 )
 
     this.xmlOffset = buffer.readUIntBE( offset + 216, 8 )
     this.xmlLength = buffer.readUIntBE( offset + 224, 8 )
 
     buffer.copy( this.reserved1, 0, offset + 232, offset + 232 + 120 )
 
-    // NOTE: Maybe make new struct (UDIF.Checksum), b/c reuse in Mish Blocks?
-    this.checksumType = buffer.readUInt32BE( offset + 352 )
-    this.checksumSize = buffer.readUInt32BE( offset + 356 )
-    this.checksum = buffer.toString( 'hex', offset + 360, offset + 360 + this.checksumSize / 8 )
+    this.checksum.parse( buffer, offset + 352 )
 
     this.imageVariant = buffer.readUInt32BE( offset + 488 )
     this.sectorCount = buffer.readUIntBE( offset + 492, 8 )

--- a/lib/image.js
+++ b/lib/image.js
@@ -154,6 +154,8 @@ Image.prototype = {
       callback.call( self, error )
     })
 
+    this.fd = null
+
     return this
 
   },

--- a/lib/image.js
+++ b/lib/image.js
@@ -15,21 +15,17 @@ function Image( path ) {
   this.path = path
   this.fd = null
   this.footer = null
-  this.resources = []
+  this.resourceFork = {}
 
 }
 
-Image.parseResourceMap = function( resourceFork ) {
+Image.parseBlkx = function( blkx ) {
 
-  var blocks = resourceFork['blkx']
   var block = null
-
-  // NOTE: What to do with `resourceFork['plst']`!?
-
   var resources = []
 
-  for( var i = 0; i < blocks.length; i++ ) {
-    block = blocks[i]
+  for( var i = 0; i < blkx.length; i++ ) {
+    block = blkx[i]
     resources.push({
       id: +block['ID'],
       attributes: +block['Attributes'],
@@ -66,7 +62,8 @@ Image.prototype = {
    * @return {Number} size in bytes
    */
   getUncompressedSize() {
-    return this.resources.reduce(( size, resource ) => {
+    if( !this.resourceFork.blkx ) return 0
+    return this.resourceFork.blkx.reduce(( size, resource ) => {
       return resource.map.blocks.reduce(( size, block ) => {
         return size + ( block.sectorCount * UDIF.SECTOR_SIZE )
       }, size )
@@ -104,9 +101,14 @@ Image.prototype = {
     fs.read( this.fd, buffer, 0, length, position, ( error, bytesRead, buffer ) => {
       if( error ) return callback.call( this, error )
       var data = plist.parse( buffer.toString() )
-      try { this.resources = Image.parseResourceMap( data['resource-fork'] ) }
-      catch( error ) { return callback.call( this, error ) }
-      callback.call( this, null, this.resources )
+      this.resourceFork = data['resource-fork']
+      try {
+        if( this.resourceFork.blkx )
+          this.resourceFork.blkx = Image.parseBlkx( this.resourceFork.blkx )
+      } catch( error ) {
+        return callback.call( this, error )
+      }
+      callback.call( this, null, this.resourceFork )
     })
 
   },

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -29,9 +29,9 @@ function ReadStream( image, options ) {
   this.image = !(image instanceof UDIF.Image) ?
     new UDIF.Image( image ) : image
 
-  // Index of current resource being handled
-  this._resource = 0
-  // Index of current resource map block being handled
+  // Index of current resource block map being handled
+  this._blockMap = 0
+  // Index of current map block being handled
   this._block = 0
 
 }
@@ -117,7 +117,7 @@ ReadStream.prototype = {
 
   _readNextBlock() {
 
-    var resource = this.image.resources[ this._resource ]
+    var resource = this.image.resourceFork.blkx[ this._blockMap ]
 
     // End once there are no resources left to read
     if( resource == null ) {
@@ -140,7 +140,7 @@ ReadStream.prototype = {
 
     // If we've read all blocks in a resource, advance to the next
     if( this._block >= resource.map.blockCount ) {
-      this._resource++
+      this._blockMap++
       this._block = 0
       return this._readNextBlock()
     }

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -24,15 +24,24 @@ function ReadStream( image, options ) {
 
   this.bytesRead = 0
   this.bytesWritten = 0
+  this.closed = false
   this.destroyed = false
 
   this.image = !(image instanceof UDIF.Image) ?
     new UDIF.Image( image ) : image
 
-  // Index of current resource block map being handled
-  this._blockMap = 0
-  // Index of current map block being handled
+  this._entry = 0
   this._block = 0
+
+  if( this.image.fd == null ) {
+    this.open()
+  }
+
+  this.on( 'end', () => {
+    if( this.autoClose ) {
+      this.destroy()
+    }
+  })
 
 }
 
@@ -63,25 +72,12 @@ ReadStream.prototype = {
     }
   },
 
-  // TODO: It probably makes more sense to implement a BlockDevice API
-  // in UDIF.Image and use that from here, but for now this is the PoC
   _readBlock( map, block, callback ) {
 
     // Don't read comments or block map terminators
     if( block.type === UDIF.BLOCK.COMMENT || block.type === UDIF.BLOCK.TERMINATOR ) {
       return void callback()
     }
-
-    // // A block's sector number is relative to it's map's sector number,
-    // // so we have to calculate the offset in bytes by adding the two,
-    // // plus the data fork's offset:
-    // var position = this.image.footer.dataForkOffset +
-    //   ( block.sectorNumber * UDIF.SECTOR_SIZE ) +
-    //   ( map.sectorNumber * UDIF.SECTOR_SIZE )
-
-    // var isCompressed = block.type === UDIF.BLOCK.UDCO ||
-    //   block.type === UDIF.BLOCK.UDZO ||
-    //   block.type === UDIF.BLOCK.UDBZ
 
     // If the block's marked as zerofill or unallocated,
     // just allocate a zerofilled buffer of that size and return it
@@ -115,68 +111,104 @@ ReadStream.prototype = {
 
   },
 
-  _readNextBlock() {
+  _readNextRange() {
 
-    var resource = this.image.resourceFork.blkx[ this._blockMap ]
+    var blkx = this.image.resourceFork.blkx
+    var entry = blkx[ this._entry ]
 
-    // End once there are no resources left to read
-    if( resource == null ) {
-      return void this.push( null )
+    if( entry == null ) {
+      return this.push( null )
     }
 
-    var block = resource.map.blocks[ this._block++ ]
-
-    if( block != null ) {
-      this._readBlock( resource.map, block, ( error, buffer ) => {
-        if( error ) {
-          this.destroy()
-          this.emit( 'error', error )
-        } else if( buffer != null ) {
-          this.bytesWritten += buffer.length
-          this.push( buffer )
-        }
-      })
-    }
-
-    // If we've read all blocks in a resource, advance to the next
-    if( this._block >= resource.map.blockCount ) {
-      this._blockMap++
+    var block = entry.map.blocks[ this._block++ ]
+    if( block == null ) {
+      this._entry++
       this._block = 0
-      return this._readNextBlock()
+      return this._readNextRange()
     }
+
+    this._readBlock( entry.map, block, ( error, buffer ) => {
+
+      if( error ) {
+        this.destroy()
+        this.emit( 'error', error )
+        return
+      }
+
+      if( buffer != null ) {
+        this.bytesWritten += buffer.length
+        this.push( buffer )
+      } else {
+        this._readNextRange()
+      }
+
+    })
 
   },
 
   _read() {
-    if( this.image.fd ) this._readNextBlock()
-    else this.image.open(( error ) => {
+
+    if( this.destroyed ) return;
+
+    if( this.image.fd != null ) {
+      this._readNextRange()
+    } else {
+      this.once( 'open', () => {
+        this._read()
+      })
+    }
+
+  },
+
+  open() {
+
+    this.image.open(( error, fd ) => {
       if( error ) {
-        return void this.emit( 'error', error )
+        if( this.autoClose ) {
+          this.destroy()
+        }
+        this.emit( 'error', error )
+      } else {
+        this.emit( 'open' )
+        this.read()
       }
-      this._readNextBlock()
     })
+
+    return this
+
   },
 
   close( callback ) {
-    this.push( null )
-    this.image.close(( error ) => {
-      this.emit( 'close', error )
-      if( callback ) {
-        callback.call( this, error )
+
+    if( callback ) {
+      this.once( 'close', callback )
+    }
+
+    if( this.closed || this.image.fd == null ) {
+      if( this.image.fd == null ) {
+        this.once( 'open', () => this.close() )
+        return
       }
+      return process.nextTick( () => this.emit( 'close' ) )
+    }
+
+    this.closed = true
+
+    this.image.close(( error ) => {
+      if( error ) this.emit( 'error', error )
+      else this.emit( 'close' )
     })
+
   },
 
   destroy() {
-    if( !this.destroyed ) {
-      this.destroyed = true
-      this.close()
-      this.emit( 'destroy' )
-    }
+    if( this.destroyed ) return
+    this.destroyed = true
+    this.close()
   },
 
 }
 
 inherit( ReadStream, Stream.Readable )
-// Exports
+
 module.exports = ReadStream

--- a/lib/udif.js
+++ b/lib/udif.js
@@ -37,6 +37,9 @@ UDIF.BLOCK = {
   TERMINATOR: 0xFFFFFFFF,
 }
 
+/** @constructor Checksum */
+UDIF.Checksum = require( './checksum' )
+
 /** @constructor Koly block */
 UDIF.Footer = require( './footer' )
 

--- a/scripts/inspect.js
+++ b/scripts/inspect.js
@@ -1,0 +1,24 @@
+var fs = require( 'fs' )
+var path = require( 'path' )
+var util = require( 'util' )
+var UDIF = require( '..' )
+
+var argv = process.argv.slice(2)
+var filename = argv[0]
+
+function inspect( value ) {
+  return util.inspect( value, {
+    depth: null, colors: process.stdout.isTTY,
+  })
+}
+
+var image = new UDIF.Image( filename )
+
+image.open(( error ) => {
+  if( error ) throw error
+  console.log( inspect( image ) )
+  image.close(( error ) => {
+    if( error ) throw error
+    var start = Date.now()
+  })
+})

--- a/scripts/speed.js
+++ b/scripts/speed.js
@@ -37,16 +37,30 @@ var ERASELINE = CURSOR_UP + CURSOR_LEFT + ERASE_LINE
 image.open(( error ) => {
   if( error ) throw error
   console.log( inspect( image ) )
+  process.stdout.write( '\n\n' )
+  console.log( '  compressed size:', bytes(image.footer.dataForkLength) )
+  console.log( 'uncompressed size:', bytes(image.getUncompressedSize()) )
+  process.stdout.write( '\n' )
   image.close(( error ) => {
     if( error ) throw error
     var start = Date.now()
-    process.stdout.write( '\n\n\n\n' )
+    var first = true
     UDIF.createReadStream( filename )
       .on( 'data', function() {
         var time = ( Date.now() - start ) / 1000
+        if( first ) {
+          process.stdout.write( '\n\n' )
+          first = false
+        }
         process.stdout.write( ERASELINE )
         process.stdout.write( `Bytes read: ${bytes(this.bytesRead)} (${bytes((this.bytesRead/time)|0)}/s)\n` )
         process.stdout.write( `Bytes written: ${bytes(this.bytesWritten)} (${bytes((this.bytesWritten/time)|0)}/s)\n` )
+      })
+      .on( 'end', function() {
+        process.stdout.write( `Done.\n` )
+      })
+      .on( 'readable', function() {
+        while( this.read() ) continue
       })
   })
 })


### PR DESCRIPTION
As came to light through https://github.com/resin-io/etcher/issues/1342, the ReadStream would not read an entire image, if there were more than a few bklx resource entries due to improper state management across reads.

This fixes ReadStream, while also introducing new Checksum objects and keeping the entire resource-fork in the image data.
