### PR TITLE
feat(readstream): Stream ZEROFILL & FREE blocks

### DIFF
--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -5,6 +5,7 @@ var bunzip = require( 'seek-bzip' )
 var adc = require( 'apple-data-compression' )
 var inherit = require( 'bloodline' )
 var UDIF = require( './udif' )
+var Zerofill = require( './zerofill-stream' )
 
 /**
  * UDIF Image ReadStream
@@ -34,6 +35,7 @@ function ReadStream( image, options ) {
 
   this._entry = 0
   this._block = 0
+  this._blockStream = null
 
   if( this.image.fd == null ) {
     this.open()
@@ -46,6 +48,13 @@ function ReadStream( image, options ) {
   })
 
 }
+
+/**
+ * Threshold at which it will resort to streaming
+ * zerofill and unallocated blocks
+ * @const {Number}
+ */
+ReadStream.STREAM_THRESHOLD = 64 * 1024
 
 /**
  * ReadStream prototype
@@ -80,6 +89,31 @@ ReadStream.prototype = {
     }
   },
 
+  _zerofillStream( block, callback ) {
+
+    var self = this
+
+    this._blockStream = new Zerofill({
+      length: block.sectorCount * UDIF.SECTOR_SIZE,
+      blockSize: UDIF.SECTOR_SIZE,
+    })
+
+    this._blockStream.on( 'error', callback )
+    this._blockStream.on( 'end', () => {
+      this._blockStream = null
+      callback()
+    })
+
+    this._blockStream.once( 'readable', () => {
+      var chunk = null
+      if( chunk = this._blockStream.read() ) {
+        this.bytesRead += chunk.length
+        this.push( chunk )
+      }
+    })
+
+  },
+
   _readBlock( map, block, callback ) {
 
     // Don't read comments or block map terminators
@@ -87,11 +121,12 @@ ReadStream.prototype = {
       return void callback()
     }
 
-    // If the block's marked as zerofill or unallocated,
-    // just allocate a zerofilled buffer of that size and return it
+    var size = block.sectorCount * UDIF.SECTOR_SIZE
+
     if( block.type === UDIF.BLOCK.ZEROFILL || block.type === UDIF.BLOCK.FREE ) {
-      var size = block.sectorCount * UDIF.SECTOR_SIZE
-      return void callback( null, Buffer.alloc( size, 0 ) )
+      return size > ReadStream.STREAM_THRESHOLD ?
+        this._zerofillStream( block, callback ) :
+        callback( null, Buffer.alloc( size, 0 ) )
     }
 
     var position = this.image.footer.dataForkOffset + block.compressedOffset
@@ -154,9 +189,40 @@ ReadStream.prototype = {
 
   },
 
+  _readStream() {
+
+    var chunk = null
+    var reads = 0
+
+    while( chunk = this._blockStream.read() ) {
+      reads++
+      this.bytesRead += chunk.length
+      if( !this.push( chunk ) ) {
+        break
+      }
+    }
+
+    if( !reads ) {
+      this._blockStream.once( 'readable', () => {
+        var chunk = null
+        while( chunk = this._blockStream.read() ) {
+          this.bytesRead += chunk.length
+          if( !this.push( chunk ) ) {
+            break
+          }
+        }
+      })
+    }
+
+  },
+
   _read() {
 
     if( this.destroyed ) return;
+
+    if( this._blockStream ) {
+      return this._readStream()
+    }
 
     if( this.opened ) {
       this._readNextRange()

--- a/lib/zerofill-stream.js
+++ b/lib/zerofill-stream.js
@@ -1,0 +1,83 @@
+var Stream = require( 'stream' )
+var inherit = require( 'bloodline' )
+
+/**
+ * ZerofillStream
+ * @constructor
+ * @param {Object} [options]
+ * @param {Number} [options.highWaterMark=65536]
+ * @param {Number} [options.fill=0]
+ * @param {Number} [options.length=Infinity]
+ * @param {Number} [options.blockSize=1]
+ * @returns {ZerofillStream}
+ */
+function ZerofillStream( options ) {
+
+  if( !(this instanceof ZerofillStream) ) {
+    return new ZerofillStream( options )
+  }
+
+  options = options || {}
+  options.highWaterMark = options.highWaterMark || ( 64 * 1024 )
+
+  Stream.Readable.call( this, options )
+
+  this.blockSize = options.blockSize || 1
+  this.fill = options.fill || 0
+  this.length = options.length || Infinity
+
+  this.highWaterMark = options.highWaterMark
+  this.bytesWritten = 0
+
+  if( this.blockSize <= 0 ) {
+    throw new Error( 'Block size must be greater than zero' )
+  }
+
+  if( !Number.isInteger( this.blockSize ) ) {
+    throw new Error( 'Block size must be a positive integer' )
+  }
+
+  if( this.length < 0 || ( +this.length !== this.length ) || Number.isNaN( this.length ) ) {
+    throw new Error( 'Length must be a positive integer' )
+  }
+
+  if( this.length !== Infinity && !Number.isInteger( this.length ) ) {
+    throw new Error( 'Length must be a positive integer' )
+  }
+
+}
+
+/**
+ * ZerofillStream prototype
+ * @ignore
+ */
+ZerofillStream.prototype = {
+
+  constructor: ZerofillStream,
+
+  _read() {
+
+    var length = this.length - this.bytesWritten
+
+    if( length <= 0 ) {
+      return void this.push( null )
+    }
+
+    length = Math.min( length, this.highWaterMark )
+    length = this.blockSize * Math.ceil( length / this.blockSize )
+    length = Math.max( length, this.blockSize )
+
+    var buffer = Buffer.alloc( length, this.fill )
+
+    this.bytesWritten += length
+    this.push( buffer )
+
+  }
+
+}
+
+// Inherit from ReadableStream
+inherit( ZerofillStream, Stream.Readable )
+
+// Exports
+module.exports = ZerofillStream


### PR DESCRIPTION
This implements streaming zerofill / unallocated blocks when their
size exceeds a certain threshold (64KB) to avoid clogging up memory,
and stalling streams when images contain larged zerofilled areas.

Connects to https://github.com/jhermsmeier/node-udif/issues/4